### PR TITLE
🐛 Fix too long reservation, fixing #28

### DIFF
--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -27,7 +27,7 @@ export function schedule(eventsOfUsers: Period[][]): Period {
       if (freeDateEnd.getTime() - freeDateStart.getTime() >= eventDuration) {
         return {
           start: freeDateStart,
-          end: freeDateEnd
+          end: new Date(freeDateStart.getTime() + eventDuration),
         };
       }
     }
@@ -67,7 +67,7 @@ export function findFreeDurations(eventsOfUsers: Period[][]): Period[] {
       freeDateEnd = change.timestamp;
 
       if (freeDateEnd.getTime() - freeDateStart.getTime() >= eventDuration) {
-        candidate.push({start: freeDateStart, end: freeDateEnd});
+        candidate.push({start: freeDateStart, end: new Date(freeDateStart.getTime() + eventDuration)});
       }
     }
 


### PR DESCRIPTION
## ユーザ視点での変更の説明

要求する空き時間の長さを超えて、日程が確保される不具合がなくなった。

## 開発者視点での変更の説明

空き時間 idle の終了時刻 idle.end を、空き時間開始時刻 idle.start に要求時間 demandedDuration を足した値に設定。

## イシュー番号・リンク

#28

## レビュー前のチェックリスト

- [x] 自分でコードの振り返りをしました
