### PR TITLE
🐛 Apply checkboxes of guests, fix #40

### DIFF
--- a/src/app/adjust/client.tsx
+++ b/src/app/adjust/client.tsx
@@ -39,10 +39,8 @@ export default function SchedulePlanner({ users }: { users: User[] }) {
 	}, [title, selectedUserIds])
 
 	async function findPeriod() {
-		// const userIds : string[]= [/* "some_id", "some_id" */];
-		const userIds = users.map(v => v.id)
 		const hostEvents = await getHostEvents()
-		const guestsEvents = await getGuestsEvents(userIds)
+		const guestsEvents = await getGuestsEvents(selectedUserIds);
 		const periodsByUser: Period[][] = [...guestsEvents, hostEvents ?? []]
 		console.log(periodsByUser)
 


### PR DESCRIPTION
## ユーザ視点での変更の説明

サインイン中の全員ではなく、希望の相手とのみ共通の空き時間を見つけられるようになりました。

## 開発者視点での変更の説明

#40 のバグを修正。/adjust で、チェックの付けられたユーザのIDのみからGoogleカレンダーの予定を取得するように変えました。

## イシュー番号・リンク

#40

## レビュー前のチェックリスト

- [x] 自分でコードの振り返りをしました
