### PR TITLE
change header class: absolute → fixed

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default async function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <header className="w-full flex justify-between items-center p-3 absolute top-0">
+        <header className="w-full flex justify-between items-center p-3 fixed top-0">
           <p>スーパーこよみ</p>
           <UserWeiget signin={Boolean(session?.user)} name={session?.user?.name ?? undefined} picture={session?.user?.image ?? undefined}  />
         </header>


### PR DESCRIPTION
## ユーザ視点での変更の説明
#39 で発生した、時間の選択欄を展開したときに header がずれる問題を解決した

## 開発者視点での変更の説明
`app/layout.tsx`, `header.position: absolute → fixed`

## イシュー番号・リンク

## レビュー前のチェックリスト

- [x] 自分でコードの振り返りをしました
