### PR TITLE
招待相手から自分自身を除くなど

### DIFF
--- a/src/app/adjust/client.tsx
+++ b/src/app/adjust/client.tsx
@@ -35,8 +35,8 @@ export default function SchedulePlanner({ users }: { users: User[] }) {
 	const [isButtonActive, setIsButtonActive] = useState(false)
 
 	useEffect(() => {
-		setIsButtonActive(title.trim() !== "" && selectedUserIds.length > 0)
-	}, [title, selectedUserIds])
+		setIsButtonActive(title.trim() !== "")
+	}, [title])
 
 	async function findPeriod() {
 		const hostEvents = await getHostEvents()

--- a/src/app/adjust/client.tsx
+++ b/src/app/adjust/client.tsx
@@ -155,14 +155,17 @@ function SelectDuration({
 				<SelectValue placeholder="Select a duration" />
 			</SelectTrigger>
 			<SelectContent>
-				{[30, 60, 90, 120, 150, 180].map(duration => {
-					const label = duration.toString()
-					return (
-						<SelectItem value={label} key={label}>
-							{formatDuration(duration)}
-						</SelectItem>
-					)
-				})}
+				{Array.from(Array(60 / 30 * 6).keys()) // 60m/h / 30m (step) * 6h (max duration)
+					.map(i => {
+						const duration = (i + 1) * 30
+						const label = duration.toString()
+						return (
+							<SelectItem value={label} key={label}>
+								{formatDuration(duration)}
+							</SelectItem>
+						)
+					})
+				}
 			</SelectContent>
 		</Select>
 	)

--- a/src/app/adjust/client.tsx
+++ b/src/app/adjust/client.tsx
@@ -86,6 +86,7 @@ export default function SchedulePlanner({ users }: { users: User[] }) {
 				<div>
 					<Label htmlFor="title">予定のタイトル</Label>
 					<Input
+						autoFocus
 						id="title"
 						value={title}
 						onChange={e => setTitle(e.target.value)}

--- a/src/app/adjust/page.tsx
+++ b/src/app/adjust/page.tsx
@@ -1,7 +1,11 @@
 import { db } from '@/lib/prisma'
 import SchedulePlanner from '@/app/adjust/client'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
 
 export default async function AdjustPage() {
-  const users = await db.allUsers()
+  const session = await getServerSession(authOptions)
+  const users = (await db.allUsers())
+    .filter(user => user.email !== session?.user.email)
   return <SchedulePlanner users={users} />
 }


### PR DESCRIPTION
## ユーザ視点での変更の説明
- 「招待する人」にログイン中の自分自身のアカウントが出てこない
- /adjust で予定名の入力がすぐに始められる
- 予定の長さの候補が6時間までに増えた

## 開発者視点での変更の説明
- adjust/page.tsx で session を参照して `users` から自身を除外
- 予定名の`Input`に`autoFocus`
- adjust/layout.tsx, `<SelectDuration/>` で長さのベタ打ちを書き換え

## イシュー番号・リンク
#43 

## レビュー前のチェックリスト

- [x] 自分でコードの振り返りをしました
