### PR TITLE
🚸 Show notification on scheduling completion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "prisma": "^5.20.0",
         "react": "^18",
         "react-dom": "^18",
+        "react-toastify": "^10.0.6",
         "shadcn-ui": "^0.2.3",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7"
@@ -5904,6 +5905,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.6.tgz",
+      "integrity": "sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prisma": "^5.20.0",
     "react": "^18",
     "react-dom": "^18",
+    "react-toastify": "^10.0.6",
     "shadcn-ui": "^0.2.3",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7"

--- a/src/app/adjust/client.tsx
+++ b/src/app/adjust/client.tsx
@@ -12,6 +12,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { ToastContainer, toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 import { ExcludePeriod, schedule } from "@/lib/scheduling"
 
@@ -58,7 +60,14 @@ export default function SchedulePlanner({ users }: { users: User[] }) {
         attendees: users.filter(user => selectedUserIds.includes(user.id)),
       });
 
-      // TODO: 追加したあと完了画面に繊維したり、追加した予定の日時を表示したり。
+      toast(
+        `カレンダーに追加されました。\n${period.start.toLocaleString()}から${selectedDurationMinute}分`,
+        {
+          onClick: () => {
+            open("https://calendar.google.com/calendar", "_blank");
+          },
+        }
+      );
     } catch (e) {
 			window.alert("Sorry, an error has occurred!")
 			console.error(e)
@@ -116,6 +125,7 @@ export default function SchedulePlanner({ users }: { users: User[] }) {
           「{title || "-"}」の日時を決定する
         </Button>
       </div>
+      <ToastContainer />
     </div>
 	)
 }


### PR DESCRIPTION
## ユーザ視点での変更の説明

日程調整完了の通知を受け取って、完了したことを確認できる。
ポップアップ通知をクリックすることで、カレンダーに遷移できる。

## 開発者視点での変更の説明

[React-toastify](https://www.npmjs.com/package/react-toastify)を用いて、addEventの直後に通知を表示した。

## イシュー番号・リンク

n/a

## レビュー前のチェックリスト

- [x] 自分でコードの振り返りをしました
