### PR TITLE
UTC帯のデプロイ環境でも除外時間帯が正しい時刻に設定される

### DIFF
--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -100,6 +100,9 @@ export async function schedule(duration: number, userIds: string[], excludePerio
   const excludePeriods: Period[] = Array.from(Array(8).keys())
     .map(offsetDays => excludePeriodOfOffsetDays(excludePeriod, offsetDays, now))
   const periodsByUser: Period[][] = [...guestsEvents, hostEvents ?? [], excludePeriods]
-  console.log(periodsByUser);
+  console.log(periodsByUser.map(periods => periods.map(period => ({
+    start: period.start.toLocaleString(),
+    end: period.end.toLocaleString()
+  }))))
   return findPeriod(duration, periodsByUser);
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -29,11 +29,14 @@ export const excludePeriodOfOffsetDays = (
 	const endOffsetDaysAdd = excludePeriod.start <= excludePeriod.end ? 0 : 1
 	const start = baseDate == undefined ? new Date() : truncateTime(baseDate)
 	const end = baseDate == undefined ? new Date() : truncateTime(baseDate)
-	start.setHours(excludePeriod.start)
-	end.setHours(excludePeriod.end)
-	start.setDate(start.getDate() + (offsetDays ?? 0))
-	end.setDate(end.getDate() + (offsetDays ?? 0) + endOffsetDaysAdd)
-	return { start, end }
+	start.setUTCHours(excludePeriod.start)
+	end.setUTCHours(excludePeriod.end)
+	start.setUTCDate(start.getUTCDate() + (offsetDays ?? 0))
+	end.setUTCDate(end.getUTCDate() + (offsetDays ?? 0) + endOffsetDaysAdd)
+	return {
+		start: shiftDateByTimezoneOffsetJST(start),
+		end: shiftDateByTimezoneOffsetJST(end)
+	}
 }
 
 export const formatDuration = (minutes: number) => {
@@ -44,3 +47,11 @@ export const formatDuration = (minutes: number) => {
 	if (remainingMinutes === 0) return `${hours}時間`
 	return `${hours}時間${remainingMinutes}分`
 }
+
+export const shiftDateByTimezoneOffset = (offsetMinutes?: number) => (date: Date): Date => {
+	const offset = offsetMinutes ?? date.getTimezoneOffset()
+	date.setUTCMinutes(date.getUTCMinutes() + offset)
+	return date
+}
+
+export const shiftDateByTimezoneOffsetJST = shiftDateByTimezoneOffset(-540);


### PR DESCRIPTION
## ユーザ視点での変更の説明
デプロイ環境でも除外時間設定が効くようになった（はず）

## 開発者視点での変更の説明
除外時間帯の時刻がUTC基準になっていたのを、時差分ずらして実質的にJSTとして解釈させるようにした。よって、JST以外の利用者は想定していない。
もっとわかりやすい時差の扱い方があればそうしたい。

## イシュー番号・リンク
#50 

## レビュー前のチェックリスト
デプロイ環境同様のUTC帯で確認するには `export TZ="UTC" && npm run dev` 

- [x] 自分でコードの振り返りをしました
