### PR TITLE
click each timeslot to add event, formatDuration in toast

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,7 +56,7 @@ model VerificationToken {
     identifier String
     token      String
     expires    DateTime
-
+    
     @@id([identifier, token])
 }
 

--- a/src/app/adjust/candidate.tsx
+++ b/src/app/adjust/candidate.tsx
@@ -1,8 +1,12 @@
+"use client"
+
 import { Button } from "@/components/ui/button"
+import { addEvent } from "@/lib/addEvent"
 import { ExcludePeriod, Period, findFreePeriods, periodsOfUsers } from "@/lib/scheduling"
-import { formatDate } from "@/lib/utils"
+import { formatDate, formatDuration } from "@/lib/utils"
 import { User } from "@prisma/client"
-import { useEffect, useState } from "react"
+import { Dispatch, useEffect, useState } from "react"
+import { toast } from "react-toastify"
 
 type Props = {
 	title: string
@@ -15,7 +19,7 @@ type Props = {
 export default function Candidate(props: Props) {
 	const [isButtonActive, setIsButtonActive] = useState(false)
 	const [freePeriods, setFreePeriods] = useState<Period[]>([])
-  const [selectedPeriod, setSelectedPeriod] = useState<Period|null>(null)
+	const [selectedPeriod, setSelectedPeriod] = useState<Period | null>(null)
 
 	useEffect(() => {
 		setIsButtonActive(props.title.trim() !== "")
@@ -27,6 +31,7 @@ export default function Candidate(props: Props) {
 			const periods = await periodsOfUsers(props.selectedUserIds, props.excludePeriod)
 
 			const freePeriods = await findFreePeriods(props.selectedDurationMinute, periods)
+			console.log("freePfreePeriods:", freePeriods)
 
 			setFreePeriods(freePeriods)
 		} catch (e) {
@@ -37,9 +42,44 @@ export default function Candidate(props: Props) {
 		}
 	}
 
-  async function handlePeriodClick(period: Period) {
-    setSelectedPeriod(period)
-  }
+	async function handlePeriodClick(period: Period) {
+		setIsButtonActive(false)
+		try {
+			// const end = new Date(period.start)
+			// end.setMinutes(end.get props.selectedDurationMinute)
+			const period_spanned: Period = {
+				start: period.start,
+				end: new Date(period.start.getTime() + 1000 * 60 * props.selectedDurationMinute),
+			}
+
+			await addEvent({
+				id: null,
+				summary: props.title,
+				start: period_spanned?.start,
+				end: period_spanned?.end,
+				description: null,
+				location: null,
+				status: "CONFIRMED",
+				attendees: props.users.filter(user => props.selectedUserIds.includes(user.id)),
+			})
+
+			toast(
+				`カレンダーに追加されました。\n${formatDate(period.start)} から${formatDuration(
+					props.selectedDurationMinute
+				)}`,
+				{
+					onClick: () => {
+						open("https://calendar.google.com/calendar", "_blank")
+					},
+				}
+			)
+		} catch (e) {
+			window.alert("Sorry, an error has occurred!")
+			console.error(e)
+		} finally {
+			setIsButtonActive(true)
+		}
+	}
 
 	return (
 		<div className="py-4">
@@ -48,17 +88,17 @@ export default function Candidate(props: Props) {
 			</Button>
 			<ul className="py-4 space-y-2">
 				{freePeriods.map(period => (
-					<li key={period.start.toString()}
-            >
+					<li key={period.start.toString()}>
 						<Button
+							disabled={!isButtonActive}
 							variant={selectedPeriod?.start === period.start ? "secondary" : "ghost"}
 							className="w-full justify-between font-normal"
 							onClick={() => handlePeriodClick(period)}>
 							<span className="flex items-center mr-2 h-4 w-4">
-                <span>{formatDate(period.start)}</span>
-                <span className="px-2">～</span>
-                <span>{formatDate(period.end)}</span>
-              </span>
+								<span>{formatDate(period.start)}</span>
+								<span className="px-2">～</span>
+								<span>{formatDate(period.end)}</span>
+							</span>
 							{/* <ChevronRight className="h-4 w-4" /> */}
 						</Button>
 					</li>
@@ -67,3 +107,23 @@ export default function Candidate(props: Props) {
 		</div>
 	)
 }
+
+// const TimeSlot = ({
+// 	setIsButtonActive
+// }: {
+// 	setIsButtonActive: React.Dispatch<React.SetStateAction<boolean>>
+// }) => {
+// 	return (
+// 		<Button
+// 							variant={selectedPeriod?.start === period.start ? "secondary" : "ghost"}
+// 							className="w-full justify-between font-normal"
+// 							onClick={() => handlePeriodClick(period)}>
+// 							<span className="flex items-center mr-2 h-4 w-4">
+//                 <span>{formatDate(period.start)}</span>
+//                 <span className="px-2">～</span>
+//                 <span>{formatDate(period.end)}</span>
+//               </span>
+// 							{/* <ChevronRight className="h-4 w-4" /> */}
+// 						</Button>
+// 	)
+// }

--- a/src/app/adjust/candidate.tsx
+++ b/src/app/adjust/candidate.tsx
@@ -5,7 +5,7 @@ import { addEvent } from "@/lib/addEvent"
 import { ExcludePeriod, Period, findFreePeriods, periodsOfUsers } from "@/lib/scheduling"
 import { formatDate, formatDuration } from "@/lib/utils"
 import { User } from "@prisma/client"
-import { Dispatch, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "react-toastify"
 
 type Props = {
@@ -44,6 +44,7 @@ export default function Candidate(props: Props) {
 
 	async function handlePeriodClick(period: Period) {
 		setIsButtonActive(false)
+		setSelectedPeriod(period)
 		try {
 			// const end = new Date(period.start)
 			// end.setMinutes(end.get props.selectedDurationMinute)
@@ -107,23 +108,3 @@ export default function Candidate(props: Props) {
 		</div>
 	)
 }
-
-// const TimeSlot = ({
-// 	setIsButtonActive
-// }: {
-// 	setIsButtonActive: React.Dispatch<React.SetStateAction<boolean>>
-// }) => {
-// 	return (
-// 		<Button
-// 							variant={selectedPeriod?.start === period.start ? "secondary" : "ghost"}
-// 							className="w-full justify-between font-normal"
-// 							onClick={() => handlePeriodClick(period)}>
-// 							<span className="flex items-center mr-2 h-4 w-4">
-//                 <span>{formatDate(period.start)}</span>
-//                 <span className="px-2">～</span>
-//                 <span>{formatDate(period.end)}</span>
-//               </span>
-// 							{/* <ChevronRight className="h-4 w-4" /> */}
-// 						</Button>
-// 	)
-// }

--- a/src/app/adjust/client.tsx
+++ b/src/app/adjust/client.tsx
@@ -19,7 +19,7 @@ import { ExcludePeriod, schedule } from "@/lib/scheduling"
 
 import { User } from "@prisma/client"
 import { addEvent } from "@/lib/addEvent";
-import { formatDuration } from "@/lib/utils";
+import { formatDate, formatDuration } from "@/lib/utils";
 import Candidate from "./candidate";
 
 // const people = [
@@ -61,9 +61,9 @@ export default function SchedulePlanner({ users }: { users: User[] }) {
         status: "CONFIRMED",
         attendees: users.filter(user => selectedUserIds.includes(user.id)),
       });
-
+      
       toast(
-        `カレンダーに追加されました。\n${period.start.toLocaleString()}から${formatDuration(selectedDurationMinute)}`,
+        `カレンダーに追加されました。\n${formatDate(period.start)} から${formatDuration(selectedDurationMinute)}`,
         {
           onClick: () => {
             open("https://calendar.google.com/calendar", "_blank");

--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -79,17 +79,16 @@ export async function findFreePeriods(eventDurationMinute: number, eventsOfUsers
       freeDateEnd = change.timestamp;
 
       if (freeDateEnd.getTime() - freeDateStart.getTime() >= eventDuration && new Date() <= freeDateStart) {
-        candidate.push({start: freeDateStart, end: new Date(freeDateStart.getTime() + eventDuration)});
+        candidate.push({start: freeDateStart, end: freeDateEnd});
       }
     }
 
     busyCount += change.countDelta;
-
+    
     if (busyCount === 0) {
       freeDateStart = change.timestamp;
     }
   }
-
   return candidate
 }
 


### PR DESCRIPTION
## ユーザ視点での変更の説明
日時の候補が、連続する空き時間全体になって、設定した予定の長さより長くなりうる。
日時の候補をクリックすると、その開始時間から設定した長さの予定が追加される。

## 開発者視点での変更の説明
CandidateのhandlePeriodClick()を実装

## イシュー番号・リンク

## レビュー前のチェックリスト

- [x] 自分でコードの振り返りをしました
