### PR TITLE
♻️ Use Freebusy Query to limit API scope

### DIFF
--- a/src/app/mycalendar/page.tsx
+++ b/src/app/mycalendar/page.tsx
@@ -11,16 +11,17 @@ export default async function Page() {
   const account = await db.findAccount(session.user.id);
   if (!account) return <h1>Account not found</h1>;
   if (!account.access_token) return <h1>Access token not found</h1>;
-  
+
   const calender = new GoogleCalendar(account.access_token);
-  const event = await calender.getEvents();
+  const event = await calender.getBusyPeriods();
+  console.log(JSON.stringify(event, null, 2));
 
   return (
     <div>
       <h1>My Calendar</h1>
       {event.map((e) => (
-        <div key={e.id} className="border p-2 flex gap-1">
-          <p>{e.summary}</p>
+        <div key={e.start.getTime()} className="border p-2 flex gap-1">
+          <p>{"BUSY"}</p>
           <p>{e.start.toLocaleDateString()}</p>
           <p>{e.end.toLocaleTimeString()}</p>
         </div>

--- a/src/lib/getEvents.ts
+++ b/src/lib/getEvents.ts
@@ -10,7 +10,7 @@ export async function getHostEvents() {
   const account = await db.findAccount(session.user.id)
   if (!account?.access_token) return
   const calendar = new GoogleCalendar(account.access_token)
-  const events = await calendar.getEvents()
+  const events = await calendar.getBusyPeriods();
   return events
 }
 
@@ -19,7 +19,7 @@ export async function getGuestsEvents(ids: string[]) {
     const account = await db.findAccount(id);
     if (!account?.access_token) return [];
     const calendar = new GoogleCalendar(account.access_token);
-    return await calendar.getEvents();
+    return await calendar.getBusyPeriods();
   });
   return Promise.all(promises);
 }

--- a/src/lib/googleApi.ts
+++ b/src/lib/googleApi.ts
@@ -7,8 +7,10 @@ if (!clientSecret) throw new Error("Missing GOOGLE_CLIENT_SECRET env var");
 export const SCOPE = [
   "https://www.googleapis.com/auth/userinfo.profile",
   "https://www.googleapis.com/auth/userinfo.email",
-  "https://www.googleapis.com/auth/calendar.readonly",
+  // "https://www.googleapis.com/auth/calendar.readonly",
   "https://www.googleapis.com/auth/calendar.app.created",
+  "https://www.googleapis.com/auth/calendar.freebusy",
+  "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
 ];
 
 export { clientId as googleClientId, clientSecret as googleClientSecret };

--- a/src/logic/calendar.ts
+++ b/src/logic/calendar.ts
@@ -14,6 +14,17 @@ export type CalEvent = {
   attendees: Attendee[];
 };
 
+export type SlimedCalEvent = {
+  id?: string | null;
+  summary?: string;
+  description?: string | null;
+  location?: string | null;
+  start: Date;
+  end: Date;
+  status?: EventStatus | null;
+  attendees?: Attendee[];
+};
+
 export type Attendee = {
   email: string | null;
 };


### PR DESCRIPTION
## ユーザ視点での変更の説明

（アプリに提供するべき個人情報が減る）

## 開発者視点での変更の説明

Google Calendar APIの必要なデータアクセス範囲を減らして、アプリ公開までの障壁を減らす。

## イシュー番号・リンク

## レビュー前のチェックリスト

- [x] 自分でコードの振り返りをしました
