### PR TITLE
日程候補の色が目に優しくなりました。また、スマートフォン用表示の改善を試みました。

### DIFF
--- a/src/app/adjust/WeekView.tsx
+++ b/src/app/adjust/WeekView.tsx
@@ -21,11 +21,13 @@ export function WeekView({ periods, currentDate, handlePeriodClick, isButtonActi
 
   return (
     <div className="max-w-full overflow-x-auto">
-      <div className="min-w-[800px]">
+      {
+      //<div className="min-w-[800px]"> //横幅
+}
         <div className="grid grid-cols-8 gap-px bg-gray-200">
           <div className="sticky left-0 bg-white "></div>
           {weekDates.map((date) => (
-            <div key={date.toISOString()} className="text-center py-2 font-semibold bg-white">
+            <div key={date.toISOString()} className="text-center text-sm sm:text-base md:text-lg lg:text-xl xl:text-2xl py-2 font-semibold bg-white">
               {date.toLocaleDateString('ja-JP', { weekday: 'short', month: 'numeric', day: 'numeric' })}
             </div>
           ))}
@@ -53,20 +55,22 @@ export function WeekView({ periods, currentDate, handlePeriodClick, isButtonActi
                         top: `${top}%`,
                         height: `${height}%`,
                         minHeight: '20px',
-                        backgroundColor: `blue`,
-                        borderColor: "blue",
-                        color: "white",
+                        backgroundColor: `#f0be5c`,//lightsteelblue#b0c4de
+                        borderColor: "#f0be5c",//lightsteelblue
+                        color: "black",
                       }}
                       onClick={() => handlePeriodClick(period)}
                     >
-                      <div>{formatTime(period.start)} - {formatTime(period.end)}</div>
+                      <div>{formatTime(period.start)}  {formatTime(period.end)}</div>
                     </button>
                   );
                 })}
             </div>
           ))}
         </div>
-      </div>
+      {
+      //</div>
+}
     </div>
   );
 }

--- a/src/app/adjust/client.tsx
+++ b/src/app/adjust/client.tsx
@@ -123,11 +123,10 @@ export default function SchedulePlanner({ users }: { users: User[] }) {
             ))}
           </div>
         </div>
-        {
-				//<Button onClick={handleSchedule} disabled={!isButtonActive} className="w-full">
-        //  「{title || "-"}」の日時を決定する
-        //</Button>
-}
+        
+				<Button onClick={handleSchedule} disabled={!isButtonActive} className="w-full">
+          「{title || "-"}」の日時を決定する
+        </Button>
       </div>
       <Candidate
         excludePeriod={excludePeriod}

--- a/src/app/adjust/client.tsx
+++ b/src/app/adjust/client.tsx
@@ -123,9 +123,11 @@ export default function SchedulePlanner({ users }: { users: User[] }) {
             ))}
           </div>
         </div>
-				<Button onClick={handleSchedule} disabled={!isButtonActive} className="w-full">
-          「{title || "-"}」の日時を決定する
-        </Button>
+        {
+				//<Button onClick={handleSchedule} disabled={!isButtonActive} className="w-full">
+        //  「{title || "-"}」の日時を決定する
+        //</Button>
+}
       </div>
       <Candidate
         excludePeriod={excludePeriod}


### PR DESCRIPTION
## ユーザ視点での変更の説明

- 日程候補の色が目に優しくなりました。
- スマートフォン用表示が改善したかもしれません。

## 開発者視点での変更の説明

- 日程候補の表示を薄いオレンジ背景に黒文字にしました
- 文字サイズの変更を試みましたが、スマートフォン環境での確認はできていません

## イシュー番号・リンク

## レビュー前のチェックリスト

- [x] 自分でコードの振り返りをしました
