### PR TITLE
除外時間帯に応じて候補表示のカレンダーを縮める

### DIFF
--- a/src/app/adjust/WeekView.tsx
+++ b/src/app/adjust/WeekView.tsx
@@ -1,23 +1,40 @@
 "use client"
 
-import React from 'react';
-import { formatTime, getEventPosition } from '../../lib/draft/utils';
-import { Period } from '@/lib/scheduling';
+import React, { useEffect, useState } from 'react';
+import { ExcludePeriodState, formatTime, getEventPosition, toCrossPeriods } from '../../lib/draft/utils';
+import { ExcludePeriod, Period } from '@/lib/scheduling';
+import { Eclipse } from 'lucide-react';
+import { setTimes } from '@/lib/utils';
 
 interface WeekViewProps {
   periods: Period[];
   currentDate: Date;
   handlePeriodClick: (period: Period) => Promise<void>
   isButtonActive: boolean
+  excludePeriodState: ExcludePeriodState,
 }
 
-export function WeekView({ periods, currentDate, handlePeriodClick, isButtonActive }: WeekViewProps) {
+export function WeekView({ periods, currentDate, handlePeriodClick, isButtonActive, excludePeriodState }: WeekViewProps) {
+  const hours = Array.from({ length: 24 }, (_, i) => i)
   const weekDates = Array.from(Array(7).keys()).map(i => {
     const date = new Date(currentDate)
     date.setDate(currentDate.getDate() + i)
     return date
   })
-  const hours = Array.from({ length: 24 }, (_, i) => i);
+  const crossPeriods = toCrossPeriods(periods)
+
+  const excludePeriod = excludePeriodState.calendar
+  // 0, 1, ...24時間から除外時間を含まない時間を抽出
+  const activeHours = hours
+    .filter(i => (excludePeriod.start <= excludePeriod.end)
+      ? (i <= excludePeriod.start || excludePeriod.end <= i)
+      : (excludePeriod.end <= i && i <= excludePeriod.start)
+    )
+
+  console.log("crossPeriods", crossPeriods)
+
+  // calendarの高さ そのまま分に対応する
+  const heightPx = 60 * activeHours.length
 
   return (
     <div className="max-w-full overflow-x-auto">
@@ -32,9 +49,9 @@ export function WeekView({ periods, currentDate, handlePeriodClick, isButtonActi
             </div>
           ))}
         </div>
-        <div className="relative grid grid-cols-8 gap-px bg-gray-200" style={{ height: '1440px' }}>
+        <div className="relative grid grid-cols-8 gap-px bg-gray-200" style={{ height: `${heightPx}px` }}>
           <div className="sticky left-0 bg-white ">
-            {hours.map((hour) => (
+            {activeHours.map((hour) => (
               <div key={hour} className="h-[60px] border-t border-gray-200 text-xs text-gray-500 text-right pr-2">
                 {`${hour}:00`}
               </div>
@@ -42,18 +59,20 @@ export function WeekView({ periods, currentDate, handlePeriodClick, isButtonActi
           </div>
           {weekDates.map((date) => (
             <div key={date.toISOString()} className="relative bg-white">
-              {periods
-                .filter((period) => period.start.toDateString() === date.toDateString())
-                .map((period) => {
-                  const { top, height } = getEventPosition(period);
+              {crossPeriods
+                .filter(period => (period.crossOpen == "start" ? period.end : period.start).toDateString() === date.toDateString())
+                .map(period => {
+                  const { top, height } = getEventPosition(period, excludePeriodState);
+                  const start = period.crossOpen == "start" ? "…" : formatTime(period.start)
+                  const end = period.crossOpen == "end" ? "…" : formatTime(period.end)
                   return (
                     <button
-                      key={period.start.toString()}
+                      key={(period.start??period.end).toString()}
                       disabled={!isButtonActive}
                       className={`absolute w-full px-1 py-1 text-xs border rounded overflow-hidden transition-opacity hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-opacity-50`}
                       style={{
-                        top: `${top}%`,
-                        height: `${height}%`,
+                        top: `${top/heightPx*100}%`,
+                        height: `${height/heightPx*100}%`,
                         minHeight: '20px',
                         backgroundColor: `#f0be5c`,//lightsteelblue#b0c4de
                         borderColor: "#f0be5c",//lightsteelblue
@@ -61,7 +80,7 @@ export function WeekView({ periods, currentDate, handlePeriodClick, isButtonActi
                       }}
                       onClick={() => handlePeriodClick(period)}
                     >
-                      <div>{formatTime(period.start)}  {formatTime(period.end)}</div>
+                      <div>{start}  {end}</div>
                     </button>
                   );
                 })}

--- a/src/app/adjust/candidate.tsx
+++ b/src/app/adjust/candidate.tsx
@@ -8,7 +8,7 @@ import { User } from "@prisma/client"
 import { useEffect, useState } from "react"
 import { toast } from "react-toastify"
 import { WeekView } from "./WeekView"
-import { ExcludePeriodState, fitExcludePeriods, toCrossPeriods } from "@/lib/draft/utils"
+import { ExcludePeriodState, fitExcludePeriods } from "@/lib/draft/utils"
 
 type Props = {
 	title: string
@@ -27,14 +27,15 @@ export default function Candidate({excludePeriod, ...props}: Props) {
 	})
 
   useEffect(()=>{
-		const threshold = fitExcludePeriods(excludePeriod, toCrossPeriods(freePeriods))
+		console.log("freePeriods", freePeriods)
+		const threshold = fitExcludePeriods(excludePeriod, freePeriods)
 		// ...excludePeriod, ...threshold として元の範囲をそこから削った範囲に上書きして excludePeriodState.calendar を更新
-		if (threshold != null) setExcludePeriodState({...excludePeriodState, calendar: {...excludePeriod, ...threshold}})
-
+		const calendar = {...excludePeriod, ...threshold}
+		if (threshold != null) setExcludePeriodState(state => ({...state, calendar}))
 
     console.log("excludePeriod", excludePeriod)
-    console.log("excludePeriodState", excludePeriodState)
     console.log("threshold", threshold)
+		console.log("ExcludePeriodState.calendar", calendar)
   }, [freePeriods, excludePeriod])
 
 	useEffect(() => {
@@ -47,7 +48,6 @@ export default function Candidate({excludePeriod, ...props}: Props) {
 			const periods = await periodsOfUsers(props.selectedUserIds, excludePeriod)
 
 			const freePeriods = await findFreePeriods(props.selectedDurationMinute, periods)
-			console.log("freePfreePeriods:", freePeriods)
 
 			setFreePeriods(freePeriods)
 			setExcludePeriodState({...excludePeriodState, calculated: excludePeriod})

--- a/src/lib/draft/utils.ts
+++ b/src/lib/draft/utils.ts
@@ -1,25 +1,185 @@
-import { Period } from '@/lib/scheduling';
+import { ExcludePeriod, Period } from "@/lib/scheduling"
+import { max, setTimes, truncateTime } from "../utils"
 
 export function getWeekDates(date: Date): Date[] {
-  const week = [];
-  const current = new Date(date);
-  current.setDate(current.getDate() - current.getDay());
-  for (let i = 0; i < 7; i++) {
-    week.push(new Date(current));
-    current.setDate(current.getDate() + 1);
-  }
-  return week;
+	const week = []
+	const current = new Date(date)
+	current.setDate(current.getDate() - current.getDay())
+	for (let i = 0; i < 7; i++) {
+		week.push(new Date(current))
+		current.setDate(current.getDate() + 1)
+	}
+	return week
 }
 
 export function formatTime(date: Date): string {
-  return date.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
+	return date.toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" })
 }
 
-export function getEventPosition(period: Period): { top: number; height: number } {
-  const start = period.start.getHours() * 60 + period.start.getMinutes();
-  const end = period.end.getHours() * 60 + period.end.getMinutes();
-  const top = (start / 1440) * 100;
-  const height = ((end - start) / 1440) * 100;
-  return { top, height };
+export type ExcludePeriodState = {
+	calculated?: ExcludePeriod
+	calendar: ExcludePeriod
 }
 
+export function getEventPosition(
+	period: CrossPeriod,
+	excludePeriodState: ExcludePeriodState
+): { top: number; height: number } {
+	const start =
+		period.crossOpen == "start" ? 0 : period.start.getHours() * 60 + period.start.getMinutes()
+	const end =
+		period.crossOpen == "end" ? 24 * 60 : period.end.getHours() * 60 + period.end.getMinutes()
+	const excludePeriod = excludePeriodState.calendar
+	const excludeDurationHours =
+		excludePeriod.start <= excludePeriod.end
+			? excludePeriod.end - excludePeriod.start
+			: 24 + excludePeriod.end - excludePeriod.start
+
+	const offsetHours =
+		excludePeriod.start <= excludePeriod.end // 除外時間帯が日付を跨がないとき
+			? (period.crossOpen == "start" ? 0 : period.start.getHours()) >= excludePeriod.end
+				? 1 - excludeDurationHours // 後ろの予定は除外時間帯の長さだけずらす。除外時間帯は表示上1の長さに圧縮されるので 1足している
+				: 0 // 除外時間帯より前の予定はそのまま
+			: excludePeriod.end * -1 // 0時から除外時間帯終了までの分を詰める
+
+	const top = start + offsetHours * 60
+	const height = end - start
+
+	return { top, height }
+}
+
+// 日付をまたぐ期間（丸一日を含む複数日には対応していない）
+export type CrossPeriod = Period & {
+	crossOpen?: "start" | "end"
+}
+export const toCrossPeriods = (periods: Period[]): CrossPeriod[] =>
+	periods.flatMap(period =>
+		period.start.toDateString() != period.end.toDateString()
+			? ([
+					{ ...period, crossOpen: "start" },
+					{ ...period, crossOpen: "end" },
+			  ] as CrossPeriod[])
+			: [period]
+	)
+
+export type MinutesPeriod = {
+	start: number
+	end: number
+}
+
+const minutesToExcludePeriod = (minutePeriod: MinutesPeriod): ExcludePeriod => ({
+	start: Math.ceil(minutePeriod.start / 60),
+	end: Math.floor(minutePeriod.end / 60),
+})
+
+export const fitExcludePeriods = (
+	excludePeriod: ExcludePeriod,
+	periods: CrossPeriod[]
+): Partial<ExcludePeriod>|null => {
+	const freeExcludePeriods = findFreeExcludePeriods(excludePeriod, periods)
+	console.log(
+		"freeExcludePeriods",
+		freeExcludePeriods.map(p => minutesToExcludePeriod(p))
+	)
+	const startSide = freeExcludePeriods.find(k => k.end == 24 * 60)
+	const endSide = freeExcludePeriods.find(k => k.start == 0)
+	if (startSide && endSide)
+		return {
+			start: Math.ceil(startSide.start / 60),
+			end: Math.floor(endSide.end / 60),
+		}
+	else {
+		freeExcludePeriods.sort((a, b) => b.end - b.start - (a.end - a.start))
+		const long = freeExcludePeriods.at(0)
+		return long ? minutesToExcludePeriod(long) : null
+	}
+}
+
+// periods と重なっていない excludePeriod の部分を抽出
+export const findFreeExcludePeriods = (
+	excludePeriod: ExcludePeriod,
+	periods: CrossPeriod[]
+): MinutesPeriod[] => {
+  console.log("findFreeExcludePeriods, periods", periods)
+	const freeBusyChanges: Array<{ timestamp: number; countDelta: 1 | -1; isExclude: boolean }> = []
+	const totalMinutes = (date: Date) => date.getHours() * 60 + date.getMinutes()
+
+	for (const event of periods) {
+		freeBusyChanges.push({
+			timestamp: event.crossOpen == "start" ? 0 : totalMinutes(event.start),
+			countDelta: 1,
+			isExclude: false,
+		})
+		freeBusyChanges.push({
+			timestamp: event.crossOpen == "end" ? 24 * 60 : totalMinutes(event.end),
+			countDelta: -1,
+			isExclude: false,
+		})
+	}
+
+	;(excludePeriod.start <= excludePeriod.end
+		? [excludePeriod]
+		: [
+				{
+					start: excludePeriod.start,
+					end: 24,
+				},
+				{
+					start: 0,
+					end: excludePeriod.end,
+				},
+		  ]
+	).forEach(excludePeriod => {
+		freeBusyChanges.push({
+			timestamp: excludePeriod.start * 60,
+			countDelta: 1,
+			isExclude: true,
+		})
+		freeBusyChanges.push({
+			timestamp: excludePeriod.end * 60,
+			countDelta: -1,
+			isExclude: true,
+		})
+	})
+
+	freeBusyChanges.sort((a, b) => a.timestamp - b.timestamp)
+	console.log("excludePeriod", excludePeriod, "freeBusyChanges", freeBusyChanges)
+
+	const candidate: MinutesPeriod[] = []
+	let noOverwrap = {
+		start: 0,
+		end: 0,
+	}
+	let busyCount = {
+		exclude: 0,
+		count: 0,
+	}
+	for (const change of freeBusyChanges) {
+		if (
+			busyCount.exclude > 0 &&
+			busyCount.count == 0 &&
+			change.countDelta == 1 &&
+			!change.isExclude
+		) {
+			noOverwrap.end = change.timestamp
+			if (noOverwrap.end - noOverwrap.start > 0) candidate.push({ ...noOverwrap }) // {...}で展開しないと shallow copy（参照複製）になってあとからの noOverwrap の変更が candidate に追加した分にも反映されて値が同じになってしまう
+		}
+
+		if (change.isExclude) {
+			busyCount.exclude = max(0, busyCount.exclude + change.countDelta)
+			if (busyCount.exclude == 0 && busyCount.count == 0) {
+				noOverwrap.end = change.timestamp
+				if (noOverwrap.end - noOverwrap.start > 0) candidate.push({ ...noOverwrap })
+			}
+		} else busyCount.count = max(0, busyCount.count + change.countDelta)
+		if (
+			busyCount.count == 0 &&
+			((change.isExclude && busyCount.exclude == 1) || (!change.isExclude && busyCount.exclude > 0))
+		)
+			noOverwrap.start = change.timestamp
+
+		console.log("change", change, "busyCount", busyCount, "noOverwrap", noOverwrap, "candidate", candidate)
+	}
+
+	return candidate
+}

--- a/src/lib/draft/utils.ts
+++ b/src/lib/draft/utils.ts
@@ -1,5 +1,5 @@
 import { ExcludePeriod, Period } from "@/lib/scheduling"
-import { max, setTimes, truncateTime } from "../utils"
+import { max, setTimes } from "../utils"
 
 export function getWeekDates(date: Date): Date[] {
 	const week = []
@@ -22,13 +22,13 @@ export type ExcludePeriodState = {
 }
 
 export function getEventPosition(
-	period: CrossPeriod,
+	period: Partial<Period>,
 	excludePeriodState: ExcludePeriodState
 ): { top: number; height: number } {
 	const start =
-		period.crossOpen == "start" ? 0 : period.start.getHours() * 60 + period.start.getMinutes()
+		period.start? (period.start.getHours() * 60 + period.start.getMinutes()): 0
 	const end =
-		period.crossOpen == "end" ? 24 * 60 : period.end.getHours() * 60 + period.end.getMinutes()
+		period.end? (period.end.getHours() * 60 + period.end.getMinutes()): 24*60
 	const excludePeriod = excludePeriodState.calendar
 	const excludeDurationHours =
 		excludePeriod.start <= excludePeriod.end
@@ -37,7 +37,7 @@ export function getEventPosition(
 
 	const offsetHours =
 		excludePeriod.start <= excludePeriod.end // 除外時間帯が日付を跨がないとき
-			? (period.crossOpen == "start" ? 0 : period.start.getHours()) >= excludePeriod.end
+			? (period.start ? period.start.getHours() : 0) >= excludePeriod.end
 				? 1 - excludeDurationHours // 後ろの予定は除外時間帯の長さだけずらす。除外時間帯は表示上1の長さに圧縮されるので 1足している
 				: 0 // 除外時間帯より前の予定はそのまま
 			: excludePeriod.end * -1 // 0時から除外時間帯終了までの分を詰める
@@ -47,20 +47,6 @@ export function getEventPosition(
 
 	return { top, height }
 }
-
-// 日付をまたぐ期間（丸一日を含む複数日には対応していない）
-export type CrossPeriod = Period & {
-	crossOpen?: "start" | "end"
-}
-export const toCrossPeriods = (periods: Period[]): CrossPeriod[] =>
-	periods.flatMap(period =>
-		period.start.toDateString() != period.end.toDateString()
-			? ([
-					{ ...period, crossOpen: "start" },
-					{ ...period, crossOpen: "end" },
-			  ] as CrossPeriod[])
-			: [period]
-	)
 
 export type MinutesPeriod = {
 	start: number
@@ -74,13 +60,9 @@ const minutesToExcludePeriod = (minutePeriod: MinutesPeriod): ExcludePeriod => (
 
 export const fitExcludePeriods = (
 	excludePeriod: ExcludePeriod,
-	periods: CrossPeriod[]
+	periods: Period[]
 ): Partial<ExcludePeriod>|null => {
-	const freeExcludePeriods = findFreeExcludePeriods(excludePeriod, periods)
-	console.log(
-		"freeExcludePeriods",
-		freeExcludePeriods.map(p => minutesToExcludePeriod(p))
-	)
+	const freeExcludePeriods = findFreeExcludePeriodsByDate(excludePeriod, periods)
 	const startSide = freeExcludePeriods.find(k => k.end == 24 * 60)
 	const endSide = freeExcludePeriods.find(k => k.start == 0)
 	if (startSide && endSide)
@@ -95,90 +77,152 @@ export const fitExcludePeriods = (
 	}
 }
 
+// periods を日付を跨がない期間に分割して日付ごとにまとめる
+// start, end が日付を跨いでいれば undefined
+export const periodsGroupByDate = (periods: Period[]): Map<number, Partial<Period>[]> => {
+  const periodsPerDate = new Map()
+  const setOrAppend = <K,V>(m: Map<K, V[]>) => (key: K, values: V[]) => {
+    const vs = m.get(key)
+    m.set(key, [...vs ?? [], ...values])
+  }
+	const set = setOrAppend(periodsPerDate)
+  periods.forEach(period => {
+    let start = period.start
+		let hasSplitted = false
+    while (true) {
+      const end = setTimes(start)(24)
+      const today = setTimes(start)(0)
+      if (end.getTime() < period.end.getTime()) {
+        set(today.getTime(), [hasSplitted ? {} : {start}])
+        today.setDate(today.getDate() + 1)
+        start = today
+				hasSplitted = true
+      } else {
+        set(today.getTime(), [hasSplitted ? { end: period.end } : {...period, start}])
+				break
+      }
+    }
+  })
+
+	return periodsPerDate
+}
+
+const totalMinutes = (date: Date) => date.getHours() * 60 + date.getMinutes()
+
 // periods と重なっていない excludePeriod の部分を抽出
-export const findFreeExcludePeriods = (
+// 日付ごとに抽出してから、それらの積を取る
+export const findFreeExcludePeriodsByDate = (
 	excludePeriod: ExcludePeriod,
-	periods: CrossPeriod[]
+	periods: Period[]
 ): MinutesPeriod[] => {
-  console.log("findFreeExcludePeriods, periods", periods)
-	const freeBusyChanges: Array<{ timestamp: number; countDelta: 1 | -1; isExclude: boolean }> = []
-	const totalMinutes = (date: Date) => date.getHours() * 60 + date.getMinutes()
+  const grouped = periodsGroupByDate(periods)
+	const freeExcludePeriodsPerDate: MinutesPeriod[][] = [] // 日付ごとの除外時間帯上の重なっていない部分
 
-	for (const event of periods) {
-		freeBusyChanges.push({
-			timestamp: event.crossOpen == "start" ? 0 : totalMinutes(event.start),
-			countDelta: 1,
-			isExclude: false,
-		})
-		freeBusyChanges.push({
-			timestamp: event.crossOpen == "end" ? 24 * 60 : totalMinutes(event.end),
-			countDelta: -1,
-			isExclude: false,
-		})
-	}
+	grouped.forEach((periodsInDay) => {
+		const freeBusyChanges: Array<{ timestamp: number; countDelta: 1 | -1; isExclude: boolean }> = []
 
-	;(excludePeriod.start <= excludePeriod.end
-		? [excludePeriod]
-		: [
-				{
-					start: excludePeriod.start,
-					end: 24,
-				},
-				{
-					start: 0,
-					end: excludePeriod.end,
-				},
-		  ]
-	).forEach(excludePeriod => {
-		freeBusyChanges.push({
-			timestamp: excludePeriod.start * 60,
-			countDelta: 1,
-			isExclude: true,
-		})
-		freeBusyChanges.push({
-			timestamp: excludePeriod.end * 60,
-			countDelta: -1,
-			isExclude: true,
-		})
-	})
-
-	freeBusyChanges.sort((a, b) => a.timestamp - b.timestamp)
-	console.log("excludePeriod", excludePeriod, "freeBusyChanges", freeBusyChanges)
-
-	const candidate: MinutesPeriod[] = []
-	let noOverwrap = {
-		start: 0,
-		end: 0,
-	}
-	let busyCount = {
-		exclude: 0,
-		count: 0,
-	}
-	for (const change of freeBusyChanges) {
-		if (
-			busyCount.exclude > 0 &&
-			busyCount.count == 0 &&
-			change.countDelta == 1 &&
-			!change.isExclude
-		) {
-			noOverwrap.end = change.timestamp
-			if (noOverwrap.end - noOverwrap.start > 0) candidate.push({ ...noOverwrap }) // {...}で展開しないと shallow copy（参照複製）になってあとからの noOverwrap の変更が candidate に追加した分にも反映されて値が同じになってしまう
+		for (const event of periodsInDay) {
+			freeBusyChanges.push({
+				timestamp: event.start ? totalMinutes(event.start) : 0,
+				countDelta: 1,
+				isExclude: false,
+			})
+			freeBusyChanges.push({
+				timestamp: event.end ? totalMinutes(event.end): 24*60,
+				countDelta: -1,
+				isExclude: false,
+			})
 		}
 
-		if (change.isExclude) {
-			busyCount.exclude = max(0, busyCount.exclude + change.countDelta)
-			if (busyCount.exclude == 0 && busyCount.count == 0) {
-				noOverwrap.end = change.timestamp
-				if (noOverwrap.end - noOverwrap.start > 0) candidate.push({ ...noOverwrap })
-			}
-		} else busyCount.count = max(0, busyCount.count + change.countDelta)
-		if (
-			busyCount.count == 0 &&
-			((change.isExclude && busyCount.exclude == 1) || (!change.isExclude && busyCount.exclude > 0))
-		)
-			noOverwrap.start = change.timestamp
+		;(excludePeriod.start <= excludePeriod.end
+			? [excludePeriod]
+			: [
+					{
+						start: excludePeriod.start,
+						end: 24,
+					},
+					{
+						start: 0,
+						end: excludePeriod.end,
+					},
+				]
+		).forEach(excludePeriod => {
+			freeBusyChanges.push({
+				timestamp: excludePeriod.start * 60,
+				countDelta: 1,
+				isExclude: true,
+			})
+			freeBusyChanges.push({
+				timestamp: excludePeriod.end * 60,
+				countDelta: -1,
+				isExclude: true,
+			})
+		})
 
-		console.log("change", change, "busyCount", busyCount, "noOverwrap", noOverwrap, "candidate", candidate)
+		freeBusyChanges.sort((a, b) => a.timestamp - b.timestamp)
+
+		const candidate: MinutesPeriod[] = []
+		const noOverwrap = {
+			start: 0,
+			end: 0,
+		}
+		const busyCount = {
+			exclude: 0,
+			count: 0,
+		}
+		for (const change of freeBusyChanges) {
+			if (
+				busyCount.exclude > 0 &&
+				busyCount.count == 0 &&
+				change.countDelta == 1 &&
+				!change.isExclude
+			) {
+				noOverwrap.end = change.timestamp
+				if (noOverwrap.end - noOverwrap.start > 0) candidate.push({ ...noOverwrap }) // {...}で展開しないと shallow copy（参照複製）になってあとからの noOverwrap の変更が candidate に追加した分にも反映されて値が同じになってしまう
+			}
+
+			if (change.isExclude) {
+				busyCount.exclude = max(0, busyCount.exclude + change.countDelta)
+				if (busyCount.exclude == 0 && busyCount.count == 0) {
+					noOverwrap.end = change.timestamp
+					if (noOverwrap.end - noOverwrap.start > 0) candidate.push({ ...noOverwrap })
+				}
+			} else busyCount.count = max(0, busyCount.count + change.countDelta)
+			if (
+				busyCount.count == 0 &&
+				((change.isExclude && busyCount.exclude == 1) || (!change.isExclude && busyCount.exclude > 0))
+			)
+				noOverwrap.start = change.timestamp
+		}
+
+		freeExcludePeriodsPerDate.push(candidate)
+	})
+
+	console.log("freeExcludePeriodsPerDate", freeExcludePeriodsPerDate)
+	// もし重なっていない除外時間帯が見つからない日があれば、空候補を返す
+	if (freeExcludePeriodsPerDate.some(exs => exs.length == 0)) return []
+
+	// freeExcludePeriodsPerDate の重なりを数え、全ての日付を通して重なっている部分を抽出
+	const candidate : MinutesPeriod[] = []
+	const changes = freeExcludePeriodsPerDate.flatMap(es => es.flatMap(e => [
+		{ at: e.start, isStart: true },
+		{ at: e.end, isStart: false }
+	]))
+	changes.sort((a, b) => a.at - b.at)
+
+	const period: MinutesPeriod = {
+		start: 0,
+		end: 0
+	}
+	let count = 0
+	for (const change of changes) {
+		if (count == freeExcludePeriodsPerDate.length && !change.isStart) {
+			period.end = change.at
+			if (period.end - period.start > 0) candidate.push({...period})
+		}
+
+		count += change.isStart ? 1 : -1
+		if (count == freeExcludePeriodsPerDate.length) period.start = change.at
 	}
 
 	return candidate

--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -84,7 +84,7 @@ export async function findFreePeriods(eventDurationMinute: number, eventsOfUsers
     }
 
     busyCount += change.countDelta;
-    
+
     if (busyCount === 0) {
       freeDateStart = change.timestamp;
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -21,6 +21,15 @@ export const dateToGCalFormat = (date: Date): string =>
 export const truncateTime = (date: Date): Date =>
 	new Date(date.getFullYear(), date.getMonth(), date.getDate())
 
+export const setTimes = (baseDate: Date) => (hours: number, minutes?: number, seconds?: number, miliseconds?: number): Date => {
+	const date = truncateTime(baseDate)
+	date.setHours(hours)
+	if (minutes) date.setMinutes(minutes)
+	if (seconds) date.setSeconds(seconds)
+	if (miliseconds) date.setMilliseconds(miliseconds)
+	return date
+}
+
 export const excludePeriodOfOffsetDays = (
 	excludePeriod: ExcludePeriod,
 	offsetDays?: number,
@@ -70,3 +79,6 @@ export const formatDate = (date: Date): string => {
 
 	return formattedDate
 }
+
+export const max = (a: number, b: number | undefined | null) => (b ? (a < b ? b : a) : a)
+export const min = (a: number, b: number | undefined | null) => (b ? (a > b ? b : a) : a)


### PR DESCRIPTION
## ユーザ視点での変更の説明
カレンダー上で除外時間帯が省略されるようになった。空き時間を算出したときのものから除外時間帯を変更しても、その空き時間に被らない範囲で省略される。

## 開発者視点での変更の説明
- 除外時間帯を表す状態として、設定とは別に、算出時のものとカレンダーに適用するものそれぞれを保存する excludePeriodState をおいた。
- getEventPosition も書き換え、カレンダー上で除外時間帯の省略に合わせて空き時間の表示位置を調整する。
- 設定した除外時間帯と、算出済みの空き時間との被りを findFreePeriods同様「状態監視法」で検出して、カレンダーに適用する部分を削り出す。

## イシュー番号・リンク

## レビュー前のチェックリスト

- [x] 自分でコードの振り返りをしました
