### PR TITLE
30日間の予定を考慮するように

### DIFF
--- a/src/app/adjust/WeekView.tsx
+++ b/src/app/adjust/WeekView.tsx
@@ -1,10 +1,12 @@
 "use client"
 
-import React from "react"
+import React, { useState } from "react"
 import { formatTime, getEventPosition } from "../../lib/draft/utils"
 import { Period } from "@/lib/scheduling"
 import { CoursePeriod, courseToPeriods } from "@/lib/course"
 import { Course } from "@/third-party/twinte-parser-type"
+import { Button } from "@/components/ui/button"
+import { ChevronLeft, ChevronRight } from "lucide-react"
 
 type WeekViewProps = {
   periods: Period[]
@@ -35,11 +37,14 @@ export function WeekView({
   isButtonActive,
   courses,
 }: WeekViewProps) {
+  const [currentWeekIndex, setCurrentWeekIndex] = useState(0)
+
   const weekDates = Array.from(Array(7).keys()).map(i => {
     const date = new Date(currentDate)
-    date.setDate(currentDate.getDate() + i)
+    date.setDate(currentDate.getDate() + i + currentWeekIndex * 7)
     return date
   })
+
   const hours = Array.from({ length: 24 }, (_, i) => i)
 
   const coursePeriods: CoursePeriod[] = courses.map(course => ({
@@ -49,9 +54,37 @@ export function WeekView({
 
   console.log("coursePeriods:", coursePeriods)
 
+  const handleNextWeek = () => {
+    setCurrentWeekIndex(prevIndex => Math.min(prevIndex + 1, 3))
+  }
+
+  const handlePreviousWeek = () => {
+    setCurrentWeekIndex(prevIndex => Math.max(prevIndex - 1, 0))
+  }
+
   /** @todo Reduce this TOO DEEP nest */
   return (
     <div className="max-w-full overflow-x-auto">
+      <div className="flex justify-between mb-4">
+        <Button
+          onClick={handlePreviousWeek}
+          disabled={currentWeekIndex === 0}
+          variant="outline"
+          size="icon"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          <span className="sr-only">過去へ</span>
+        </Button>
+        <Button
+          onClick={handleNextWeek}
+          disabled={currentWeekIndex === 3}
+          variant="outline"
+          size="icon"
+        >
+          <ChevronRight className="h-4 w-4" />
+          <span className="sr-only">先へ</span>
+        </Button>
+      </div>
       <div className="grid grid-cols-8 gap-px bg-gray-200">
         <div className="sticky left-0 bg-white "></div>
         {weekDates.map(date => (

--- a/src/app/adjust/candidate.tsx
+++ b/src/app/adjust/candidate.tsx
@@ -25,7 +25,7 @@ type Props = {
 export default function Candidate(props: Props) {
   const [isButtonActive, setIsButtonActive] = useState(false)
   const [freePeriods, setFreePeriods] = useState<Period[]>([])
-  const [selectedPeriod, setSelectedPeriod] = useState<Period | null>(null)
+  // const [selectedPeriod, setSelectedPeriod] = useState<Period | null>(null)
   const [spannedPeriod, setSpannedPeriod] = useState<Period | null>(null)
 
   const yesNoDialogRef = useRef<HTMLDialogElement>(null)
@@ -94,7 +94,7 @@ export default function Candidate(props: Props) {
   }
 
   async function handlePeriodClick(period: Period) {
-    setSelectedPeriod(period)
+    // setSelectedPeriod(period)
 
     const period_spanned: Period = {
       start: period.start,

--- a/src/lib/googleCalendar.ts
+++ b/src/lib/googleCalendar.ts
@@ -1,7 +1,7 @@
 import { Calendar, CalEvent, DEFAULT_EVENT, EventStatus, SlimedCalEvent } from "@/logic/calendar"
 import { google, calendar_v3 } from "googleapis"
 
-const FETCH_EVENTS_DURATION = 7 * 24 * 60 * 60 * 1000
+const FETCH_EVENTS_DURATION = 30 * 24 * 60 * 60 * 1000
 
 const SUPER_KOYOMI_CALENDAR_NAME = "スーパーこよみで追加された予定"
 

--- a/src/lib/googleCalendar.ts
+++ b/src/lib/googleCalendar.ts
@@ -1,7 +1,8 @@
 import { Calendar, CalEvent, DEFAULT_EVENT, EventStatus, SlimedCalEvent } from "@/logic/calendar"
 import { google, calendar_v3 } from "googleapis"
 
-const FETCH_EVENTS_DURATION = 30 * 24 * 60 * 60 * 1000
+export const FETCH_EVENTS_DAYS = 30
+const FETCH_EVENTS_DURATION = FETCH_EVENTS_DAYS * 24 * 60 * 60 * 1000
 
 const SUPER_KOYOMI_CALENDAR_NAME = "スーパーこよみで追加された予定"
 

--- a/src/lib/scheduling.ts
+++ b/src/lib/scheduling.ts
@@ -2,6 +2,7 @@
 
 import { getGuestsEvents, getHostEvents } from "@/lib/getEvents"
 import { excludePeriodOfOffsetDays } from "./utils"
+import { FETCH_EVENTS_DAYS } from "./googleCalendar"
 
 const DURATION_STEP_MILLISEC = 30 * 60e3
 
@@ -136,7 +137,7 @@ export async function periodsOfUsers(userIds: string[], excludePeriod: ExcludePe
   const hostEvents = await getHostEvents()
   const guestsEvents = await getGuestsEvents(userIds)
   const now = new Date()
-  const excludePeriods: Period[] = Array.from(Array(8).keys()).map(offsetDays =>
+  const excludePeriods: Period[] = Array.from(Array(FETCH_EVENTS_DAYS + 1).keys()).map(offsetDays =>
     excludePeriodOfOffsetDays(excludePeriod, offsetDays, now),
   )
   const periodsOfUsers: Period[][] = [...guestsEvents, hostEvents ?? [], excludePeriods]


### PR DESCRIPTION
## ユーザ視点での変更の説明
30日間というより長い時間にわたって予定が考慮されるようになりました。

## 開発者視点での変更の説明
FETCH_EVENTS_DURATION を30日間に
WeekView.tsx に前後の矢印ボタンを追加してカレンダーをめくれるように

## イシュー番号・リンク

## レビュー前のチェックリスト

- [x] 自分でコードの振り返りをしました
