### PR TITLE
授業時間を現在のモジュールに合わせて表示するようにgetCurrentModule()を変更しました

### DIFF
--- a/src/lib/course.ts
+++ b/src/lib/course.ts
@@ -1,6 +1,6 @@
 import { setTimes } from "./utils"
 import { Period } from "./scheduling"
-import { Course, Day } from "@/third-party/twinte-parser-type"
+import { Course, Day, Module } from "@/third-party/twinte-parser-type"
 import { FETCH_EVENTS_DAYS } from "./const"
 
 export type CoursePeriod = {
@@ -47,9 +47,43 @@ const isNextSchedule = (prevSchedule: CourseSchedule, schedule: CourseSchedule) 
 /**
  * 現在（or与えられた日時が？）どのモジュール期間であるかを返します。
  * @todo
+ * @returns 基本の６モジュールの時はその文字列を返す（"春A"）。そうでない場合は"Unknown"を返す。
  */
-const getCurrentModule = () => {
-  return "秋B"
+const getCurrentModule = (): Module => {
+	//春Aから秋Cまでの開始と終了日時を定義
+	const startSpringA = new Date(2024, 4, 15)
+	const startSpringB = new Date(2024, 5, 24)
+	const startSpringC = new Date(2024, 7, 5)
+	const endSpringC = new Date(20204, 8, 9)
+	const startFallA = new Date(2024, 10, 1)
+	const startFallB = new Date(2024, 11, 11)
+	const endFallB = new Date(2024, 12, 25)
+	const startFallC = new Date(2025, 1, 6)
+	const endFallC = new Date(2025, 2, 27)
+	//現在の日時を取得
+	const currentDate = new Date()
+	if (currentDate < startSpringA) {
+		return Module.Unknown
+	}
+	if (currentDate >= startSpringA && currentDate < startSpringB) {
+		return Module.SpringA
+	}
+	if (currentDate >= startSpringB && currentDate < startSpringC) {
+		return Module.SpringB
+	}
+	if (currentDate >= startSpringC && currentDate < endSpringC) {
+		return Module.SpringC
+	}
+	if (currentDate >= startFallA && currentDate < startFallB) {
+		return Module.FallA
+	}
+	if (currentDate >= startFallB && currentDate < endFallB) {
+		return Module.FallB
+	}
+	if (currentDate >= startFallC && currentDate < endFallC) {
+		return Module.FallC
+	}
+	return Module.Unknown
 }
 
 /**
@@ -60,7 +94,7 @@ const getCurrentModule = () => {
  */
 export const courseToPeriods = (baseDate: Date, course: Course): Period[] => {
   const currentModule = getCurrentModule()
-  const currentSchedules = course.schedules.filter(s => s.module == currentModule)
+  const currentSchedules = course.schedules.filter(s => s.module == currentModule.toString())
   const periods = currentSchedules
     .flatMap(s => {
       const nextClassDate = nextDateOfDay(baseDate, s.day)

--- a/src/lib/course.ts
+++ b/src/lib/course.ts
@@ -50,40 +50,40 @@ const isNextSchedule = (prevSchedule: CourseSchedule, schedule: CourseSchedule) 
  * @returns 基本の６モジュールの時はその文字列を返す（"春A"）。そうでない場合は"Unknown"を返す。
  */
 const getCurrentModule = (): Module => {
-	//春Aから秋Cまでの開始と終了日時を定義
-	const startSpringA = new Date(2024, 4, 15)
-	const startSpringB = new Date(2024, 5, 24)
-	const startSpringC = new Date(2024, 7, 5)
-	const endSpringC = new Date(20204, 8, 9)
-	const startFallA = new Date(2024, 10, 1)
-	const startFallB = new Date(2024, 11, 11)
-	const endFallB = new Date(2024, 12, 25)
-	const startFallC = new Date(2025, 1, 6)
-	const endFallC = new Date(2025, 2, 27)
-	//現在の日時を取得
-	const currentDate = new Date()
-	if (currentDate < startSpringA) {
-		return Module.Unknown
-	}
-	if (currentDate >= startSpringA && currentDate < startSpringB) {
-		return Module.SpringA
-	}
-	if (currentDate >= startSpringB && currentDate < startSpringC) {
-		return Module.SpringB
-	}
-	if (currentDate >= startSpringC && currentDate < endSpringC) {
-		return Module.SpringC
-	}
-	if (currentDate >= startFallA && currentDate < startFallB) {
-		return Module.FallA
-	}
-	if (currentDate >= startFallB && currentDate < endFallB) {
-		return Module.FallB
-	}
-	if (currentDate >= startFallC && currentDate < endFallC) {
-		return Module.FallC
-	}
-	return Module.Unknown
+  //春Aから秋Cまでの開始と終了日時を定義
+  const startSpringA = new Date(2024, 4, 15)
+  const startSpringB = new Date(2024, 5, 24)
+  const startSpringC = new Date(2024, 7, 5)
+  const endSpringC = new Date(20204, 8, 9)
+  const startFallA = new Date(2024, 10, 1)
+  const startFallB = new Date(2024, 11, 11)
+  const endFallB = new Date(2024, 12, 25)
+  const startFallC = new Date(2025, 1, 6)
+  const endFallC = new Date(2025, 2, 27)
+  //現在の日時を取得
+  const currentDate = new Date()
+  if (currentDate < startSpringA) {
+    return Module.Unknown
+  }
+  if (currentDate >= startSpringA && currentDate < startSpringB) {
+    return Module.SpringA
+  }
+  if (currentDate >= startSpringB && currentDate < startSpringC) {
+    return Module.SpringB
+  }
+  if (currentDate >= startSpringC && currentDate < endSpringC) {
+    return Module.SpringC
+  }
+  if (currentDate >= startFallA && currentDate < startFallB) {
+    return Module.FallA
+  }
+  if (currentDate >= startFallB && currentDate < endFallB) {
+    return Module.FallB
+  }
+  if (currentDate >= startFallC && currentDate < endFallC) {
+    return Module.FallC
+  }
+  return Module.Unknown
 }
 
 /**


### PR DESCRIPTION
## ユーザ視点での変更の説明
- 現在日時のモジュールに対応した時間割が表示されるようになり、ますます日程調整がしやすくなりました。

## 開発者視点での変更の説明
- src/lib/course.ts内のgetCurrentModule()を変更した。
- getCurrentModule()内で春Aから秋Cまでの開始と終了日時を手打ちで定義している。
- 現状は、現在日時に応じた時間割を表示している。

## イシュー番号・リンク

## レビュー前のチェックリスト

- [x] 自分でコードの振り返りをしました
