### PR TITLE
Google OIDC で Refresh token を取得できるように

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,11 +5,6 @@ import { prisma } from "@/lib/prisma"
 import GoogleProvider from "next-auth/providers/google"
 import { googleClientId, googleClientSecret, SCOPE } from "@/lib/googleApi"
 
-/** * @NOTE
- * Google OIDC はユーザの初回ログイン時はリフレッシュトークンを返却しないらしいが
- * まぁテストなので複数階ログインするだろうし許容する
- * https://next-auth.js.org/providers/google
- */
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   providers: [
@@ -19,6 +14,11 @@ export const authOptions: NextAuthOptions = {
       authorization: {
         params: {
           scope: SCOPE.join(" "),
+          // Refresh token を取得するため
+          // https://next-auth.js.org/providers/google
+          prompt: "consent",
+          access_type: "offline",
+          response_type: "code",
         },
       },
     }),


### PR DESCRIPTION
## ユーザ視点での変更の説明

"Invalid Credentials" のエラーによる自分の予定が取得できない解決されます。

## 開発者視点での変更の説明

Google ログイン時に渡されるパラメータを変更し、毎回 Refresh token を取得できるようにしました。
"Invalid Credentials" のエラーが発生する理由は Refresh token が取得できておらず Access token が更新できないためと推測しています。

https://next-auth.js.org/providers/google によると Refresh token を取得するには以下の方法があります。

- 取得ユーザが明示的に Google アカウントの管理画面でアプリの権限を剥奪し、再ログインする。
- 認証時のパラメータを今回の PR のように変更する。

すでにログイン実績のあるユーザに頼み権限を剥奪してもらうのは現実的ではないため、今回は 2 つめの方法にしています。
ただしこの方法であっても、初回は DB のリセットは必要かもです。

## イシュー番号・リンク

## レビュー前のチェックリスト

- [x] 自分でコードの振り返りをしました。
