### PR TITLE
既定値を与えて必ずしもタイトルを入力しなくてもすむようにした

### DIFF
--- a/src/app/adjust/candidate.tsx
+++ b/src/app/adjust/candidate.tsx
@@ -5,7 +5,7 @@ import { addEvent } from "@/lib/addEvent"
 import { ExcludePeriod, Period, findFreePeriods, periodsOfUsers } from "@/lib/scheduling"
 import { formatDate, formatDuration } from "@/lib/utils"
 import { User } from "@prisma/client"
-import { useEffect, useRef, useState } from "react"
+import { useRef, useState } from "react"
 import { toast } from "react-toastify"
 import { WeekView } from "./WeekView"
 import { Course } from "@/third-party/twinte-parser-type"
@@ -13,6 +13,7 @@ import { YesNoDialog } from "@/components/ui/dialog"
 import { coursePeriodsThroughWeeks } from "@/lib/course"
 import { CoursePeriod } from "@/lib/course"
 import { getUserCourseCodes } from "@/lib/server"
+import { DEFAULT_TITLE } from "@/lib/const"
 
 type Props = {
   title: string
@@ -26,16 +27,17 @@ type Props = {
 }
 
 export default function Candidate(props: Props) {
-  const [isButtonActive, setIsButtonActive] = useState(false)
+  const [isButtonActive, setIsButtonActive] = useState(true)
+  const title = props.title.trim() == "" ? DEFAULT_TITLE : props.title.trim()
   const [freePeriods, setFreePeriods] = useState<Period[]>([])
   // const [selectedPeriod, setSelectedPeriod] = useState<Period | null>(null)
   const [spannedPeriod, setSpannedPeriod] = useState<Period | null>(null)
 
   const yesNoDialogRef = useRef<HTMLDialogElement>(null)
 
-  useEffect(() => {
-    setIsButtonActive(props.title.trim() !== "")
-  }, [props.title])
+  // useEffect(() => {
+  //   setIsButtonActive(props.title.trim() !== "")
+  // }, [props.title])
 
   // 自分の授業とその時間の配列
   const coursePeriods: CoursePeriod[] = coursePeriodsThroughWeeks(props.courses, new Date())
@@ -84,7 +86,7 @@ export default function Candidate(props: Props) {
     try {
       await addEvent({
         id: null,
-        summary: props.title,
+        summary: title,
         start: period_spanned?.start,
         end: period_spanned?.end,
         description: null,
@@ -137,7 +139,7 @@ export default function Candidate(props: Props) {
         onNo={() => {}}
       />
       <Button onClick={handleSchedule} disabled={!isButtonActive} className="w-full">
-        「{props.title || "-"}」の日時候補を探す
+        「{title}」の日時候補を探す
       </Button>
       {freePeriods.length > 0 ? (
         <WeekView

--- a/src/app/adjust/client.tsx
+++ b/src/app/adjust/client.tsx
@@ -20,6 +20,7 @@ import { formatDuration } from "@/lib/utils"
 import Candidate from "./candidate"
 import { Course } from "@/third-party/twinte-parser-type"
 import ImportFileButton from "@/components/ImportFileButton"
+import { DEFAULT_TITLE } from "@/lib/const"
 
 // const people = [
 // 	{ id: 1, name: "HosokawaR", mail: "superkoyomi1@gmail.com" },
@@ -56,7 +57,7 @@ export default function SchedulePlanner(props: {
             id="title"
             value={title}
             onChange={e => setTitle(e.target.value)}
-            placeholder="予定のタイトルを入力"
+            placeholder={DEFAULT_TITLE}
           />
         </div>
         <div>

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -1,1 +1,2 @@
 export const FETCH_EVENTS_DAYS = 30
+export const DEFAULT_TITLE = "スーパーこよみで追加された予定"


### PR DESCRIPTION
## ユーザ視点での変更の説明
予定のタイトル入力が必須でなくなった

## 開発者視点での変更の説明
`const.ts` に 定数 `DEFAULT_TITLE` を作って、 placeholder や日程調整ボタンの文言をそちらを使ったものに変更

## イシュー番号・リンク

## レビュー前のチェックリスト

- [x] 自分でコードの振り返りをしました
