### PR TITLE
確認文言を日本語にして、日時範囲の表示を改善

### DIFF
--- a/src/app/adjust/candidate.tsx
+++ b/src/app/adjust/candidate.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/ui/button"
 import { addEvent } from "@/lib/addEvent"
 import { ExcludePeriod, Period, findFreePeriods, periodsOfUsers } from "@/lib/scheduling"
-import { formatDate, formatDuration } from "@/lib/utils"
+import { formatPeriod } from "@/lib/utils"
 import { User } from "@prisma/client"
 import { useEffect, useRef, useState } from "react"
 import { toast } from "react-toastify"
@@ -93,16 +93,11 @@ export default function Candidate(props: Props) {
         attendees: props.users.filter(user => props.selectedUserIds.includes(user.id)),
       })
 
-      toast(
-        `カレンダーに追加されました。\n${formatDate(period_spanned.start)} から${formatDuration(
-          props.selectedDurationMinute,
-        )}`,
-        {
-          onClick: () => {
-            open("https://calendar.google.com/calendar", "_blank")
-          },
+      toast(`${formatPeriod(period_spanned)} に追加されました`, {
+        onClick: () => {
+          open("https://calendar.google.com/calendar", "_blank")
         },
-      )
+      })
     } catch (e) {
       toast("Sorry, calendar event addition error!", { type: "error", autoClose: false })
       console.error(e)
@@ -128,11 +123,20 @@ export default function Candidate(props: Props) {
     addConfirmedPeriodToCalendar(spannedPeriod)
   }
 
+  const periodMessage = spannedPeriod ? `の ${formatPeriod(spannedPeriod)} ` : ""
+
+  const dialogMessage =
+    props.selectedUserIds.length > 0
+      ? `自分のカレンダー${periodMessage}に追加して招待を送りますか？`
+      : `自分のカレンダー${periodMessage}に追加しますか？`
+
   return (
     <div className="py-4">
       <YesNoDialog
-        message="Are you sure you want to add this event to your calendar?"
+        message={dialogMessage}
         ref={yesNoDialogRef}
+        yesButton="はい"
+        noButton="やめる"
         onYes={() => handleDialogConfirm()}
         onNo={() => {}}
       />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -4,20 +4,22 @@ import { Button } from "@/components/ui/button"
 
 interface YesNoDialogOptions {
   message: string
+  yesButton: string
+  noButton: string
   onYes?: () => void
   onNo?: () => void
 }
 
 export const YesNoDialog = forwardRef<HTMLDialogElement, YesNoDialogOptions>(
-  ({ message, onYes, onNo }, ref) => {
+  ({ message, yesButton, noButton, onYes, onNo }, ref) => {
     return (
       <dialog ref={ref} className="p-4 rounded-lg shadow-lg">
         <div className="mb-4">{message}</div>
         <form method="dialog">
           <Button onClick={onNo} variant="outline">
-            No
+            {noButton}
           </Button>
-          <Button onClick={onYes}>Yes</Button>
+          <Button onClick={onYes}>{yesButton}</Button>
         </form>
       </dialog>
     )

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -90,5 +90,32 @@ export const formatDate = (date: Date): string => {
   return formattedDate
 }
 
+export const formatPeriod = ({ start, end }: Period): string => {
+  const sames: string[] = []
+  if (start.getFullYear() == end.getFullYear()) sames.push("year")
+  if (start.getMonth() == end.getMonth()) sames.push("month")
+  if (start.getDate() == end.getDate()) sames.push("day")
+  if (start.getHours() == end.getHours()) sames.push("hour")
+
+  const startFormatted = formatDate(start)
+  const options = {
+    year: "numeric",
+    month: "long", // 'short' for abbreviated month names
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    // second: '2-digit',
+    // timeZoneName: 'short' // Shows the time zone
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const endFormatted = end.toLocaleString(
+    "ja-JP",
+    Object.fromEntries(Object.entries(options).filter(([prop, _]) => !sames.includes(prop))),
+  )
+
+  return `${startFormatted} - ${endFormatted}`
+}
+
 // export const max = (a: number, b: number | undefined | null) => (b ? (a < b ? b : a) : a)
 // export const min = (a: number, b: number | undefined | null) => (b ? (a > b ? b : a) : a)


### PR DESCRIPTION
## ユーザ視点での変更の説明
選択後の確認文言が日本語になり、そこでも選択した日時が確認できるようになった。
![image](https://github.com/user-attachments/assets/a02807aa-ccb1-4efb-8590-756e07d2fe52)


## 開発者視点での変更の説明
yesNoDialog を日本語にして、招待相手がいるかいないかによって文言を変えた (`adjust/candidate.tsx`)

`lib/utils/formatPeriod`関数を追加した。

## イシュー番号・リンク

## レビュー前のチェックリスト

- [x] 自分でコードの振り返りをしました
